### PR TITLE
Added missing LIBCSPLIT_EXTERN for libcsplit_wide_split_string_* functions defined in libcsplit.h

### DIFF
--- a/libcsplit/libcsplit_wide_split_string.h
+++ b/libcsplit/libcsplit_wide_split_string.h
@@ -67,21 +67,25 @@ int libcsplit_wide_split_string_initialize(
      int number_of_segments,
      libcerror_error_t **error );
 
+LIBCSPLIT_EXTERN \
 int libcsplit_wide_split_string_free(
      libcsplit_wide_split_string_t **split_string,
      libcerror_error_t **error );
 
+LIBCSPLIT_EXTERN \
 int libcsplit_wide_split_string_get_string(
      libcsplit_wide_split_string_t *split_string,
      wchar_t **string,
      size_t *string_size,
      libcerror_error_t **error );
 
+LIBCSPLIT_EXTERN \
 int libcsplit_wide_split_string_get_number_of_segments(
      libcsplit_wide_split_string_t *split_string,
      int *number_of_segments,
      libcerror_error_t **error );
 
+LIBCSPLIT_EXTERN \
 int libcsplit_wide_split_string_get_segment_by_index(
      libcsplit_wide_split_string_t *split_string,
      int segment_index,
@@ -89,6 +93,7 @@ int libcsplit_wide_split_string_get_segment_by_index(
      size_t *string_segment_size,
      libcerror_error_t **error );
 
+LIBCSPLIT_EXTERN \
 int libcsplit_wide_split_string_set_segment_by_index(
      libcsplit_wide_split_string_t *split_string,
      int segment_index,


### PR DESCRIPTION
The `libcsplit_wide_split_string_*` are declared in libcsplit.h as part of the public API, but aren't marked as  `LIBCSPLIT_EXTERN` in libcsplit/libcsplit_wide_split_string.h. This prevents them from appearing in the libcsplit.dll.a produced by MinGW, and hence they can't be linked to. This patch fixes that.
